### PR TITLE
Fix problem with package_installer.R script

### DIFF
--- a/package_installer.R
+++ b/package_installer.R
@@ -27,7 +27,7 @@ cran.packages <- c("e1071",
                    "RCurl",
                    "reshape",
                    "RJSONIO",
-                   "scales"
+                   "scales",
                    "tm",
                    "XML")
 


### PR DESCRIPTION
Add missing comma in package_installer.R script that causes an 'unexpected string constant' when you try to run the script
