### PR TITLE
TDM throws a 'no applicable method for meta' error due to incorrect to_l...

### DIFF
--- a/06-Regularization/chapter06.R
+++ b/06-Regularization/chapter06.R
@@ -393,7 +393,7 @@ documents <- data.frame(Text = ranks$Long.Desc.)
 row.names(documents) <- 1:nrow(documents)
 
 corpus <- Corpus(DataframeSource(documents))
-corpus <- tm_map(corpus, tolower)
+corpus <- tm_map(corpus, content_transformer(tolower))
 corpus <- tm_map(corpus, stripWhitespace)
 corpus <- tm_map(corpus, removeWords, stopwords('english'))
 


### PR DESCRIPTION
...ower conversion
- Fixed by wrapping the call in 'content_transformer'
- See http://stackoverflow.com/questions/25551514/termdocumentmatrix-errors-in-r
