### PR TITLE
update for R 3.4.1 at scale_x_date

### DIFF
--- a/01-Introduction/ufo_sightings.R
+++ b/01-Introduction/ufo_sightings.R
@@ -118,7 +118,7 @@ head(ufo.us)
 # We can do this by creating a histogram of frequencies for UFO sightings over time
 quick.hist <- ggplot(ufo.us, aes(x = DateOccurred)) +
   geom_histogram() + 
-  scale_x_date(breaks = "50 years")
+  scale_x_date(date_breaks = "50 years",date_labels = "%Y")
   
 ggsave(plot = quick.hist,
        filename = file.path("images", "quick_hist.pdf"),
@@ -134,7 +134,7 @@ new.hist <- ggplot(ufo.us, aes(x = DateOccurred)) +
   geom_histogram(aes(fill='white', color='red')) +
   scale_fill_manual(values=c('white'='white'), guide="none") +
   scale_color_manual(values=c('red'='red'), guide="none") +
-  scale_x_date(breaks = "50 years")
+  scale_x_date(date_breaks = "50 years",date_labels = "%Y")
 
 ggsave(plot = new.hist,
        filename = file.path("images", "new_hist.pdf"),


### PR DESCRIPTION
The problem lies in the ggplot function scale_x_date. In the original code this is coded as:
```
quick.hist <- ggplot(ufo.us, aes(x = DateOccurred)) +
  geom_histogram() + 
  scale_x_date(breaks = "50 years")
```
The breaks in scale_x_date has been adjusted to date_breaks. If you adjust the code to the following it works.

```
quick.hist <- ggplot(ufo.us, aes(x = DateOccurred)) +
  geom_histogram() + 
  scale_x_date(date_breaks = "50 years", date_labels = "%Y")
```